### PR TITLE
Add DestroyAllWith function to EntityManager

### DIFF
--- a/include/ecs/EntityManager.hh
+++ b/include/ecs/EntityManager.hh
@@ -87,6 +87,14 @@ namespace ecs
 		void DestroyAll();
 
 		/**
+		 * Calls Destroy() on all Entities that match a specific KeyType value.
+		 * 
+		 * This function will only find components added with the AssignKey() function.
+		 */
+		template <typename KeyType, typename... CompTypes>
+		void DestroyAllWith(const KeyType &key);
+
+		/**
 		 * Check if the entity is still valid in the system.
 		 * An entity is invalid if it is not currently present in the system.
 		 * Since Entity::Id and Entity objects are often passed by value it is useful

--- a/include/ecs/EntityManagerImpl.hh
+++ b/include/ecs/EntityManagerImpl.hh
@@ -205,6 +205,17 @@ namespace ecs
 		}
 	}
 
+	template<typename KeyType, typename... CompTypes>
+	inline void EntityManager::DestroyAllWith(const KeyType &key) 
+	{
+		auto entityCollection = EntitiesWith<KeyType, CompTypes...>(key);
+
+		for (auto ent : entityCollection) 
+		{
+			ent.Destroy();
+		}
+	}
+
 	inline bool EntityManager::Valid(Entity::Id e) const
 	{
 		return e && e.Generation() == entIndexToGen.at(e.Index());


### PR DESCRIPTION
Adds a new function to the EntityManager, `DestroyAllWith()`, which is effectively a simple wrapper around the `EntitiesWith<KeyType, CompTypes...>(KeyType& key)` function.

This can be used to destroy only entities that have a particular key value. This is useful, for example, if you want to destroy all entities created by a particular class when that class is destructed. You can ensure that all entities created by a class assign a unique KeyType to its Entities, and then in the destructor call `EntityManager::DestroyAllWith(MyClassKey)`. 

While this is less performant than calling `DestroyAll()`, using `DestroyAllWith()` ensures that Entities created by other objects are not affected by a different object being destroyed.